### PR TITLE
updating the name of the main package vignette in the documentation

### DIFF
--- a/man/McMasterPandemic-package.Rd
+++ b/man/McMasterPandemic-package.Rd
@@ -11,9 +11,9 @@ forecasting and analysis of infectious disease pandemics.
 }
 \details{
 To get started, read the introductory vignette, which can be viewed via
-\code{vignette("McMasterPandemic-intro",package="McMasterPandemic")}.
+\code{vignette("getting_started",package="McMasterPandemic")}.
 Use \code{browseVignettes("McMasterPandemic")} to find other vignettes
-for this package.  
+for this package.
 
 While (even the strictly deterministic version of) the model is
 not implemented as ODEs, its solutions are similar to those of the


### PR DESCRIPTION
@davidearn, I believe the name of the main package vignette is outdated in `McMasterPandemic-package.Rd`. I believe this PR should fix it, though I wasn't sure if that man page was dynamically generated and so the source actually needs to be updated instead.